### PR TITLE
Gres bug

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,0 +1,20 @@
+# slurm/client.pp
+#
+# Puts SLURM on any client. No service other than munge with run.
+#
+# version 20190101
+#
+# Copyright (c) CERN, 2016-2017
+# Authors: - Philippe Ganz <phganz@cern.ch>
+#          - Carolina Lindqvist <calindqv@cern.ch>
+#          - Pablo Llopis <pablo.llopis@cern.ch>
+# License: GNU GPL v3 or later.
+#
+
+class slurm::client {
+
+  include ::slurm::setup
+  include ::slurm::config
+
+  Class['::slurm::setup'] -> Class['::slurm::config']
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -192,7 +192,7 @@ class slurm::config (
   Enum['acct_gather_energy/none','acct_gather_energy/ipmi','acct_gather_energy/rapl'] $acct_gather_energy_type = 'acct_gather_energy/none',
   Enum['acct_gather_interconnect/none','acct_gather_interconnect/ofed','acct_gather_infiniband/ofed'] $acct_gather_interconnect_type = 'acct_gather_interconnect/none',
   Enum['acct_gather_filesystem/none','acct_gather_filesystem/lustre'] $acct_gather_filesystem_type = 'acct_gather_filesystem/none',
-  Enum['acct_gather_profile/none','acct_gather_profile/hdf5'] $acct_gather_profile_type = 'acct_gather_profile/none',
+  Enum['acct_gather_profile/none','acct_gather_profile/hdf5', 'acct_gather_profile/influxdb' ] $acct_gather_profile_type = 'acct_gather_profile/none',
 
   Optional[Array[String]] $debug_flags = undef,
   Enum['iso8601','iso8601_ms','rfc5424','rfc5424_ms','clock','short'] $log_time_format = 'iso8601_ms',
@@ -342,10 +342,12 @@ class slurm::config (
   # Accounting gatherer configuration file
   if  ('acct_gather_energy/ipmi' in $acct_gather_energy_type) or
       ('acct_gather_profile/hdf5' in $acct_gather_profile_type) or
+      ('acct_gather_profile/influxdb' in $acct_gather_profile_type) or
       (['acct_gather_infiniband/ofed', 'acct_gather_interconnect/ofed'] in $acct_gather_interconnect_type) {
     class{ '::slurm::config::acct_gather':
       with_energy_ipmi       => ('acct_gather_energy/ipmi' in $acct_gather_energy_type),
       with_profile_hdf5      => ('acct_gather_profile/hdf5' in $acct_gather_profile_type),
+      with_profile_influxdb  => ('acct_gather_profile/influxdb' in $acct_gather_profile_type),
       with_interconnect_ofed => (['acct_gather_infiniband/ofed', 'acct_gather_interconnect/ofed'] in $acct_gather_interconnect_type),
     }
 

--- a/manifests/config/acct_gather.pp
+++ b/manifests/config/acct_gather.pp
@@ -10,6 +10,12 @@
 # @param profile_hdf5_dir This parameter is the path to the shared folder into which the acct_gather_profile plugin will write detailed data (usually as an HDF5 file).
 # @param profile_hdf5_default A comma delimited list of data types to be collected for each job submission.
 # @param interconnect_ofed_port This parameter represents the port number of the local Infiniband card that we are willing to monitor.
+# @param profile_influxdb_host This parameter is mandatory when the influxdb plugin is setup and should contain information of the influxdb server in the following format: <hostname>:<port>
+# @param profile_influxdb_db This parameter is mandatory when the influxdb plugin is setup. Database must already exist in the influxdb server.
+# @param profile_influxdb_default A comma delimited list of data types to be collected for each job submission. 
+# @param profile_influxdb_rtpolicy The InfluxDB retention policy name for the database configured in 'profile_influxdb_db' option.
+# @param profile_influxdb_username Optinal InfluxDB username that should be used to gain access to the database configured with 'profile_influxdb_db'
+# @param profile_influxdb_password Optional password for username configured with 'profile_influxdb_username'.
 #
 # version 20170816
 #
@@ -32,6 +38,13 @@ class slurm::config::acct_gather (
   String $profile_hdf5_default = 'None',
   Boolean $with_interconnect_ofed = false,
   Integer[0] $interconnect_ofed_port = 1,
+  Boolean $with_profile_influxdb = false,
+  Optional[String] $profile_influxdb_host = undef,
+  Optional[String] $profile_influxdb_db = undef,
+  String           $profile_influxdb_default = 'None',
+  Optional[String] $profile_influxdb_rtpolicy = undef,
+  Optional[String] $profile_influxdb_username = undef,
+  Optional[String] $profile_influxdb_password = undef,
 ) {
 
   # AcctGather* plugin configuration

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@
 #
 
 class slurm (
-  Enum['worker','head','db','db-head','none'] $node_type,
+  Enum['worker','head','db','db-head','client','none'] $node_type,
 ) {
 
   case $node_type {
@@ -33,6 +33,10 @@ class slurm (
     'db-head': {
       class{'::slurm::headnode':}
       class{'::slurm::dbnode':}
+    }
+
+    'client': {
+      class{'::slurm::client':}
     }
 
     'none': {

--- a/templates/acct_gather.conf.erb
+++ b/templates/acct_gather.conf.erb
@@ -51,3 +51,20 @@ InfinibandOFEDPort=<%= @interconnect_ofed_port %>
 <% else -%>
 #InfinibandOFEDPort=
 <% end %>
+
+# Options used for AcctGatherProfileType/influxdb
+<% if @with_profile_influxdb -%>
+ProfileInfluxDBHost=<%= @profile_influxdb_host %>
+ProfileInfluxDBDatabase=<%= @profile_influxdb_db %>
+<%= @profile_influxdb_username.nil? ? '#ProfileInfluxDBUser=' : ('ProfileInfluxDBUser=' + @profile_influxdb_username) %>
+<%= @profile_influxdb_password.nil? ? '#ProfileInfluxDBPass=' : ('ProfileInfluxDBPass=' + @profile_influxdb_password) %>
+ProfileInfluxDBDefault=<%= @profile_influxdb_default %>
+ProfileInfluxDBRTPolicy=<%= @profile_influxdb_rtpolicy %>
+<% else -%>
+# ProfileInfluxDBDatabase=
+# ProfileInfluxDBDefault=
+# ProfileInfluxDBHost=
+# ProfileInfluxDBPass=
+# ProfileInfluxDBRTPolicy=
+# ProfileInfluxDBUser=
+<% end -%>

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -35,7 +35,7 @@ ExtSensorsType=<%= @ext_sensors_type %>
 ExtSensorsFreq=<%= @ext_sensors_freq %>
 FirstJobId=<%= @first_job_id %>
 MaxJobId=<%= @max_job_id %>
-<%= @gres_types.nil? ? '#GresTypes=' : ('GresTypes=' + @gres_types) %>
+<%= @gres_types.nil? ? '#GresTypes=' : ('GresTypes=' + @gres_types.join(',')) %>
 GroupUpdateForce=<%= @group_update_force %>
 JobCheckpointDir=<%= @job_checkpoint_dir %>
 JobContainerType=<%= @job_container_type %>


### PR DESCRIPTION
'gres_types' parameter is an 'Optional[Array[String]]', should contain
and Array of Strings or be 'undef'. However, template 'slurm.conf.erb'
does not reflect this and when gres_types is defined puppet crashes.

This update collects the Array and applies a join separated by comma,
solving the mentioned problem.