### PR TITLE
Select type parameters should be an Array

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -144,7 +144,7 @@ class slurm::config (
   Enum['sched/backfill','sched/builtin','sched/hold'] $scheduler_type = 'sched/backfill',
   Optional[Array[String]] $scheduler_parameters = undef,
   Enum['select/bluegene','select/cons_res','select/cray','select/linear','select/serial'] $select_type = 'select/linear',
-  Optional[Enum['OTHER_CONS_RES','NHC_ABSOLUTELY_NO','NHC_NO_STEPS','NHC_NO','CR_CPU','CR_CPU_Memory','CR_Core','CR_Core_Memory','CR_ONE_TASK_PER_CORE','CR_CORE_DEFAULT_DIST_BLOCK','CR_LLN','CR_Pack_Nodes','CR_Socket','CR_Socket_Memory','CR_Memory']] $select_type_parameters = undef,
+  Optional[Array[Enum['OTHER_CONS_RES','NHC_ABSOLUTELY_NO','NHC_NO_STEPS','NHC_NO','CR_CPU','CR_CPU_Memory','CR_Core','CR_Core_Memory','CR_ONE_TASK_PER_CORE','CR_CORE_DEFAULT_DIST_BLOCK','CR_LLN','CR_Pack_Nodes','CR_Socket','CR_Socket_Memory','CR_Memory']]] $select_type_parameters = undef,
   Integer[0] $vsize_factor = 0,
 
   Enum['priority/basic','priority/multifactor'] $priority_type = 'priority/basic',

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -226,7 +226,7 @@ SchedulerParameters=<%= @scheduler_parameters.join(',') %>
 <% end -%>
 <%#                                                                          -%>
 SelectType=<%= @select_type %>
-<%= @select_type_parameters.nil? ? '#SelectTypeParameters=' : ('SelectTypeParameters=' + @select_type_parameters) %>
+<%= @select_type_parameters.nil? ? '#SelectTypeParameters=' : ('SelectTypeParameters=' + @select_type_parameters.join(',') %>
 VSizeFactor=<%= @vsize_factor %>
 
 

--- a/templates/slurm.conf.erb
+++ b/templates/slurm.conf.erb
@@ -226,7 +226,7 @@ SchedulerParameters=<%= @scheduler_parameters.join(',') %>
 <% end -%>
 <%#                                                                          -%>
 SelectType=<%= @select_type %>
-<%= @select_type_parameters.nil? ? '#SelectTypeParameters=' : ('SelectTypeParameters=' + @select_type_parameters.join(',') %>
+<%= @select_type_parameters.nil? ? '#SelectTypeParameters=' : ('SelectTypeParameters=' + @select_type_parameters.join(',')) %>
 VSizeFactor=<%= @vsize_factor %>
 
 


### PR DESCRIPTION
Multiple options are possible. It should be an Array. Changes must be performed at the yaml definition for the setting ``slurm::config::select_type_parameters``